### PR TITLE
"close" spans can now be added in the initial DOM to avoid a FOUC without breaking the plugin behavior

### DIFF
--- a/ui.tabs.closable.js
+++ b/ui.tabs.closable.js
@@ -20,15 +20,15 @@ $.extend($.ui.tabs.prototype, {
         // if closable tabs are enable, add a close button
         if (self.options.closable === true) {
 
-            var unclosable_lis = this.lis.filter(function() {
-                // return the lis that do not have a close button
-                return $('span.ui-icon-circle-close', this).length === 0;
-            });
-
             // append the close button and associated events
-            unclosable_lis.each(function() {
+            this.lis.each(function() {
                 $(this)
-                    .append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>')
+                    .filter(function() {
+		                // return the lis that do not have a close button
+		                return $('span.ui-icon-circle-close', this).length === 0;
+		            })
+                    	.append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>')
+                    .end()
                     .find('a:last')
                         .hover(
                             function() {

--- a/ui.tabs.closable.js
+++ b/ui.tabs.closable.js
@@ -7,27 +7,28 @@
  * http://github.com/andrewwatts/ui.tabs.closable
  */
 (function() {
-    
-var ui_tabs_tabify = $.ui.tabs.prototype._tabify;
+
+var ui_tabs_parent = $.ui.tabs.prototype._refresh?$.ui.tabs.prototype._refresh:$.ui.tabs.prototype._tabify;
 
 $.extend($.ui.tabs.prototype, {
 
-    _tabify: function() {
-        var self = this;
-
-        ui_tabs_tabify.apply(this, arguments);
+    _refresh: function() {
+        var self = this,
+            lis = this.tablist?this.tablist.children( ":has(a[href])" ):this.lis;
+		
+        ui_tabs_parent.apply(this, arguments);
 
         // if closable tabs are enable, add a close button
         if (self.options.closable === true) {
 
             // append the close button and associated events
-            this.lis.each(function() {
+            lis.each(function() {
                 $(this)
-                    .filter(function() {
+                	.filter(function() {
 		                // return the lis that do not have a close button
 		                return $('span.ui-icon-circle-close', this).length === 0;
 		            })
-                    	.append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>')
+                        .append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>')
                     .end()
                     .find('a:last')
                         .hover(
@@ -38,22 +39,28 @@ $.extend($.ui.tabs.prototype, {
                                 $(this).css('cursor', 'default');
                             }
                         )
-                        .click(function() {
-                            var index = self.lis.index($(this).parent());
+                        .click(function(ev) {
+                            var index = lis.index($(this).parent());
+                            
+                            // don't follow the link
+                            ev.preventDefault();
+                            
                             if (index > -1) {
                                 // call _trigger to see if remove is allowed
-                                if (false === self._trigger("closableClick", null, self._ui( $(self.lis[index]).find( "a" )[ 0 ], self.panels[index] ))) return;
+                                if (false === self._trigger("closableClick", null, self._ui( $(lis[index]).find( "a" )[ 0 ], self.panels[index] ))) return;
 
                                 // remove this tab
                                 self.remove(index)
                             }
-
-                            // don't follow the link
-                            return false;
                         })
                     .end();
             });
         }
+    },
+    
+    // For jQueryUI 1.8 backwards compatibility only
+    _tabify: function() {
+        this._refresh.apply(this, arguments);
     }
 });
     

--- a/ui.tabs.closable.min.js
+++ b/ui.tabs.closable.min.js
@@ -6,5 +6,5 @@
  * 
  * http://github.com/andrewwatts/ui.tabs.closable
  */
-(function(){var c=$.ui.tabs.prototype._tabify;$.extend($.ui.tabs.prototype,{_tabify:function(){var a=this;c.apply(this,arguments);a.options.closable===true&&this.lis.filter(function(){return $("span.ui-icon-circle-close",this).length===0}).each(function(){$(this).append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>').find("a:last").hover(function(){$(this).css("cursor","pointer")},function(){$(this).css("cursor","default")}).click(function(){var b=a.lis.index($(this).parent());
-if(b>-1){if(false===a._trigger("closableClick",null,a._ui($(a.lis[b]).find("a")[0],a.panels[b])))return;a.remove(b)}return false}).end()})}})})(jQuery);
+(function(){var c=$.ui.tabs.prototype._tabify;$.extend($.ui.tabs.prototype,{_tabify:function(){var a=this;c.apply(this,arguments);!0===a.options.closable&&this.lis.each(function(){$(this).filter(function(){return 0===$("span.ui-icon-circle-close",this).length}).append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>').end().find("a:last").hover(function(){$(this).css("cursor","pointer")},function(){$(this).css("cursor","default")}).click(function(){var b=a.lis.index($(this).parent());
+if(-1<b){if(!1===a._trigger("closableClick",null,a._ui($(a.lis[b]).find("a")[0],a.panels[b])))return;a.remove(b)}return!1}).end()})}})})(jQuery);

--- a/ui.tabs.closable.min.js
+++ b/ui.tabs.closable.min.js
@@ -6,5 +6,5 @@
  * 
  * http://github.com/andrewwatts/ui.tabs.closable
  */
-(function(){var c=$.ui.tabs.prototype._tabify;$.extend($.ui.tabs.prototype,{_tabify:function(){var a=this;c.apply(this,arguments);!0===a.options.closable&&this.lis.each(function(){$(this).filter(function(){return 0===$("span.ui-icon-circle-close",this).length}).append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>').end().find("a:last").hover(function(){$(this).css("cursor","pointer")},function(){$(this).css("cursor","default")}).click(function(){var b=a.lis.index($(this).parent());
-if(-1<b){if(!1===a._trigger("closableClick",null,a._ui($(a.lis[b]).find("a")[0],a.panels[b])))return;a.remove(b)}return!1}).end()})}})})(jQuery);
+(function(){var c=$.ui.tabs.prototype._refresh?$.ui.tabs.prototype._refresh:$.ui.tabs.prototype._tabify;$.extend($.ui.tabs.prototype,{_refresh:function(){var a=this,d=this.tablist?this.tablist.children(":has(a[href])"):this.lis;c.apply(this,arguments);!0===a.options.closable&&d.each(function(){$(this).filter(function(){return 0===$("span.ui-icon-circle-close",this).length}).append('<a href="#"><span class="ui-icon ui-icon-circle-close"></span></a>').end().find("a:last").hover(function(){$(this).css("cursor",
+"pointer")},function(){$(this).css("cursor","default")}).click(function(c){var b=d.index($(this).parent());c.preventDefault();-1<b&&!1!==a._trigger("closableClick",null,a._ui($(d[b]).find("a")[0],a.panels[b]))&&a.remove(b)}).end()})},_tabify:function(){this._refresh.apply(this,arguments)}})})(jQuery);


### PR DESCRIPTION
To avoid a FOUC, we can add the "close" span directly into the initial DOM.
That caused the plugin not to bind events on these pre-added spans.
Now events are bound on all "close" spans, no matter if they were added by the plugin or were already present in the DOM.
